### PR TITLE
switch to optparse-applicative

### DIFF
--- a/Development/Shake/Install/Rules.hs
+++ b/Development/Shake/Install/Rules.hs
@@ -68,7 +68,7 @@ configureTheEnvironment (rootDir, _) sm _ = Just action where
           , penvAdditionalPkgConfDirectories = desiredPackageDbs sm
           }
 
-        pfx | ShakeConfigure{desiredPrefix = prefix} <- sm = rootDir </> prefix
+        pfx | ShakeConfigure ConfigureOpts{desiredPrefix = prefix} <- sm = rootDir </> prefix
             | otherwise = rootDir </> "build" </> "dist"
 
     return $! Response penv

--- a/shake-install.cabal
+++ b/shake-install.cabal
@@ -11,7 +11,7 @@ Copyright:           Alpha Heavy Industries
 Category:            Distribution
 Build-type:          Simple
 
-Cabal-version:       >=1.10
+Cabal-version:       >=1.18
 
 Executable shake
   Default-Language:  Haskell2010
@@ -20,8 +20,8 @@ Executable shake
 
   Build-depends:     base         >= 4.4 && < 5,
                      binary       ,
-                     Cabal        >= 0.16,
-                     cmdargs      ,
+                     Cabal        >= 1.18,
+                     optparse-applicative ,
                      containers   ,
                      deepseq      ,
                      directory    ,


### PR DESCRIPTION
Switch to optparse-applicative.

Due to either the temptation of convenience or the programming pattern from CmdArgs, the code looked like this:

```
 data ShakeMode
  = ShakeClean
      { desiredVerbosity :: Shake.Verbosity
      , desiredThreads   :: Maybe Int
      , desiredStaunch   :: Bool
      }
  | ShakeBuild
      { ..
```

It now looks like this

```
data ShakeMode
  = ShakeClean CleanOpts
  | ShakeBuild BuildOpts
      { ..
```

The previous style meant that many accessors of `ShakeMode` were partial functions. The new style removes that possibility.
It also means that options can properly exist only where they should be.
However, I was very confused as to what should be global and what should be limited to fewer sub-commands.

So please run with this to organize the commands even further.


## Testing

It compiles! I have not been able to get shake-install to work properly for me yet. So I am relying on your testing.

I did compare the help output of the old & the new, and it seemed to make sense.

The install action seems to no longer be working.